### PR TITLE
Adds JavaScript function to duplicate skills

### DIFF
--- a/index.html
+++ b/index.html
@@ -457,20 +457,6 @@
                 <li><span>Apache</span></li>
                 <li><span>Gunicorn</span></li>
                 <li><span>Configuration Management</span></li>
-                <li><span>Terraform</span></li>
-                <li><span>CloudFormation</span></li>
-                <li><span>AWS</span></li>
-                <li><span>Python</span></li>
-                <li><span>Docker</span></li>
-                <li><span>Linux</span></li>
-                <li><span>BASH</span></li>
-                <li><span>Ansible</span></li>
-                <li><span>CI/CD</span></li>
-                <li><span>GitHub Actions</span></li>
-                <li><span>Nginx</span></li>
-                <li><span>Apache</span></li>
-                <li><span>Gunicorn</span></li>
-                <li><span>Configuration Management</span></li>
             </ul>
             </section>
         </section>

--- a/scripts.js
+++ b/scripts.js
@@ -64,13 +64,26 @@ function showAbout() {
     // Show about container
     document.getElementById('about-container').classList.remove('hidden');
 
+    // Call the doubleSkills function
+    doubleSkills();
+
 
     // Hide projects content
     // document.getElementById('project-container').classList.add('hidden');
     // document.getElementById('project-description-container').classList.add('hidden');
 }
 
+function doubleSkills() {
+    //Appends the skill section with doubles to implement infinite scroll
+    const scrollerOuter = document.getElementById("outer-scroller");
+    const scrollerInner = document.getElementById("inner-scroller");
+    const scrollerContent = Array.from(scrollerInner.children);
 
+    scrollerContent.forEach(item => {
+        const duplicatedItem = item.cloneNode(true);
+        scrollerInner.appendChild(duplicatedItem);
+    });
+}
 
 function goHome() {
     // Show headshot and paragraph text


### PR DESCRIPTION
This commit adds a JavaScript function to duplicate the skills section items so that duplicate HTML does not need to be written for each item. This is necessary in order to allow infinite scrolling, but still keeps the HTML clean and easy to read.