### PR TITLE
Fixes mobile layout of about menu section

### DIFF
--- a/index.html
+++ b/index.html
@@ -440,32 +440,32 @@
             </p>
         </section>
         <section class="skills">
-            <h2>Tools & Skills</h2>
+            <h2>Relevant Skills</h2>
             <section id="outer-scroller">
             <ul id="inner-scroller">
-                <li><span>Apache</span></li>
-                <li><span>Nginx</span></li>
+                <li><span>Linux</span></li>
+                <li><span>Docker</span></li>
+                <li><span>Containerization</span></li>
+                <li><span>Python</span></li>
+                <li><span>BASH</span></li>
                 <li><span>Scripting</span></li>
-                <li><span>Cloud Infrastructure</span></li>
-                <li><span>AWS CodePipeline</span></li>
                 <li><span>Jenkins</span></li>
+                <li><span>AWS CodePipeline</span></li>
                 <li><span>GitHub Actions</span></li>
                 <li><span>CI/CD</span></li>
-                <li><span>Docker</span></li>
-                <li><span>Python</span></li>
-                <li><span>AWS</span></li>
                 <li><span>Ansible</span></li>
+                <li><span>Configuration Management</span></li>
                 <li><span>CloudFormation</span></li>
                 <li><span>Terraform</span></li>
-                <li><span>BASH</span></li>
-                <li><span>Linux</span></li>
-                <li><span>Gunicorn</span></li>
-                <li><span>Django</span></li>
+                <li><span>AWS</span></li>
                 <li><span>SQL</span></li>
                 <li><span>JavaScript</span></li>
-                <li><span>CSS</span></li>
                 <li><span>HTML</span></li>
-                <li><span>Configuration Management</span></li>
+                <li><span>CSS</span></li>
+                <li><span>Gunicorn</span></li>
+                <li><span>Django</span></li>
+                <li><span>Nginx</span></li>
+                <li><span>Apache</span></li>
             </ul>
             </section>
         </section>

--- a/styles.css
+++ b/styles.css
@@ -580,7 +580,7 @@ a {
         font-size: 16px;
     }
 
-    .project-category li:active {
+    .project-category li:hover {
         transform: scale(1.05);
     }
 
@@ -592,7 +592,7 @@ a {
         align-self: center;
     }
 
-    .project-list li:active {
+    .project-list li:hover {
         transform: scale(1.02);
     }
 
@@ -633,7 +633,7 @@ a {
     #about-container {
         flex-direction: column;
         width: 100%;
-        height: 83vh;
+        height: 84vh;
         justify-content: flex-start;
     }
     
@@ -687,5 +687,19 @@ a {
         to {
             transform: translateX(calc(50% - .5rem))
         }
+    }
+}
+
+@media (max-height: 700px) {
+
+    .project-category li {
+        font-size: 15px;
+        line-height: 140%;
+    }
+
+    .project-list {
+        font-size: 13px;
+        max-height: 20vh;
+        overflow-y: auto;
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -208,7 +208,7 @@ a {
     display: flex;
     flex-wrap: wrap;
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-start;
     margin-left: 21.8%;
     border: 1px solid var(--main);
     padding-left: 1%;
@@ -564,6 +564,7 @@ a {
         justify-content: flex-start;
         align-content: center;
         flex-wrap: nowrap;
+        height: 80vh;
     }
 
     .project-category {
@@ -591,13 +592,13 @@ a {
         align-self: center;
     }
 
-    .project-list li:hover {
+    .project-list li:active {
         transform: scale(1.02);
     }
 
     #project-description-container {
-        /* flex-shrink: 1;
-        overflow-y: auto; */
+        height: auto;
+        overflow-y: auto;
         width: 99%;
         align-self: center;
         margin: 0;
@@ -609,6 +610,7 @@ a {
         margin-bottom: 6%;
         line-height: 150%;
     }
+
 
     .project-description p {
         font-size: 12px;

--- a/styles.css
+++ b/styles.css
@@ -162,13 +162,15 @@ a {
 .project-category {
     width: 16%;
     height: fit-content;
-    font-size: 1.5vw;
-    line-height: 200%;
+    line-height: 3.6vi;
     margin: 1%;
     padding: 1%;
     list-style: none;
     border: 1px solid var(--main);
     animation: fadeIn 1200ms ease; 
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
 }
 
 .project-category li {
@@ -191,11 +193,11 @@ a {
     display: none;
     list-style: inside;
     border: 1px solid var(--main);
-    animation: fadeIn 700ms ease;
 }
 
 .project-list li {
     transition: transform 0.1 ease;
+    animation: fadeIn 700ms ease;
 }
 
 .project-list li:hover {
@@ -543,10 +545,15 @@ a {
         margin-bottom: 3%;
     }
 
+    .home-section h3 {
+        margin-bottom: 0;
+    }
+
     .home-section a {
         font-size: 14px;
         margin: .5vi;
     }
+
     .home-section p {
         font-size: 14px;
         margin-left: 5%;
@@ -568,11 +575,12 @@ a {
     }
 
     .project-category {
+        margin-top: 3%;
+        margin-bottom: 3%; 
         border: none;
         text-align: center;
         height: fit-content;
         width: 100%;
-        align-self: center;
     }
 
     .project-category li {
@@ -590,6 +598,7 @@ a {
         font-size: 15px;
         line-height: 175%;
         align-self: center;
+        animation: fadeIn 700ms ease;
     }
 
     .project-list li:hover {
@@ -645,8 +654,17 @@ a {
         margin-bottom: 3%;
     }
 
+    .bio p {
+        font-size: 14px;
+        line-height: 1.2;
+        padding: 2%;
+    }
+
     .skills span {
-        padding: 4% !important;
+        background-color: rgb(30, 30, 30);
+        display: inline-block;
+        padding: 0.5rem;
+        margin: 0.5rem;
     }
 
     .skills {
@@ -670,17 +688,18 @@ a {
     }
     #inner-scroller {
         flex-direction: row;
-        justify-content: space-around;
+        justify-content: flex-end;
         align-items: center;
         animation: scroll 46s linear infinite;
-        gap: 1rem;
         flex-wrap: nowrap;
     } 
 
     .skills li {
+        letter-spacing: .8px;
         white-space: nowrap;
         text-align: center;
         font-size: 14px;
+        padding: 0;
     }
 
     @keyframes scroll {

--- a/styles.css
+++ b/styles.css
@@ -1,10 +1,9 @@
 /************ GLOBAL ****************/
 
 :root {
-    --main: #dde1e6;
     --highlight: #7d93ff;
     --dark_blue: rgb(14, 14, 70);
-    --small-font: 1.2vw;
+    --main: #dde1e6;
 }
 
 .background-gradient {
@@ -93,7 +92,7 @@ a {
 
 /***** Tagline *****/
 .home-section h2 {
-    font-size: var(--small-font);
+    font-size: 1.2vw;
     opacity: 0.6;
     font-weight: 1;
     margin-top: 1%;
@@ -272,14 +271,14 @@ a {
     height: 55vh;
     display: flex;
     flex-direction: row;
-    justify-content: space-between;
+    justify-content: space-around;
     width: 90%;
     animation: fadeIn 1600ms ease;
 }
 
 .bio {
     display: block;
-    width: 80%;
+    width: 75%;
     height: auto;
     border: 1px solid var(--main);
     overflow-y: scroll;
@@ -316,7 +315,7 @@ a {
 }
 #outer-scroller {
     display: flex;
-    mask: linear-gradient(rgba(0,0,0,0) 0%, rgba(0,0,0,1) 25%, rgba(0,0,0,1) 75%, rgba(0,0,0,0) 100%);
+    mask: linear-gradient(rgba(0,0,0,0) 0%, rgba(0,0,0,1) 20%, rgba(0,0,0,1) 80%, rgba(0,0,0,0) 100%);
     height: 88%;
     overflow-y: hidden;
     flex-direction: column;
@@ -331,7 +330,7 @@ a {
     justify-content: flex-end;
     height: fit-content;
     position: relative;
-    animation: scroll 40s linear infinite;
+    animation: scroll 34s linear infinite;
 }
 
 .skills span {

--- a/styles.css
+++ b/styles.css
@@ -281,7 +281,7 @@ a {
     width: 75%;
     height: auto;
     border: 1px solid var(--main);
-    overflow-y: scroll;
+    overflow-y: auto;
     scroll-behavior: smooth;
 }
 
@@ -323,6 +323,7 @@ a {
 }
 
 #inner-scroller {
+    display: flex;
     list-style: none;
     flex-wrap: nowrap;
     flex-direction: column;
@@ -556,18 +557,7 @@ a {
         margin: 10% auto;
     }
 
-    #about-container {
-        width: 100%;
-        justify-content: center;
-    }
-
-    .bio {
-        width: 75%;
-    }
-
-    .skills {
-        width: 25%;
-    }
+    /********* PROJECTS *********/
 
     #project-container {
         flex-direction: column;
@@ -597,7 +587,7 @@ a {
         height: fit-content;
         width: 100%;
         font-size: 15px;
-        line-height: 200%;
+        line-height: 175%;
         align-self: center;
     }
 
@@ -606,7 +596,9 @@ a {
     }
 
     #project-description-container {
-        width: 101%;
+        /* flex-shrink: 1;
+        overflow-y: auto; */
+        width: 99%;
         align-self: center;
         margin: 0;
     }
@@ -632,5 +624,66 @@ a {
     .project-description ul {
         font-size: 12px;
         line-height: 150%;
+    }
+
+    /****** ABOUT *******/
+
+    #about-container {
+        flex-direction: column;
+        width: 100%;
+        height: 83vh;
+        justify-content: flex-start;
+    }
+    
+    .bio {
+        justify-content: flex-start;
+        width: 100%;
+        flex-grow: 1;
+        flex-shrink: 1;
+        margin-bottom: 3%;
+    }
+
+    .skills span {
+        padding: 4% !important;
+    }
+
+    .skills {
+        padding-top: 1%;
+        width: 100%;
+        flex-grow: 0;
+        flex-shrink: 0;
+        height: 25px;
+        margin-top: auto;
+    }
+
+    .skills h2 {
+        display: none;
+    }
+
+    #outer-scroller {
+        flex-direction: row;
+        justify-content: flex-end;
+        align-items: center;
+        overflow: hidden;
+    }
+    #inner-scroller {
+        flex-direction: row;
+        justify-content: space-around;
+        align-items: center;
+        animation: scroll 46s linear infinite;
+        gap: 1rem;
+        flex-wrap: nowrap;
+    } 
+
+    .skills li {
+        white-space: nowrap;
+        text-align: center;
+        font-size: 14px;
+    }
+
+    @keyframes scroll {
+        to {
+            transform: translateX(calc(50% - .5rem))
+        }
     }
 }


### PR DESCRIPTION
This merge fixes the layout of the mobile version of the about menu. The scroller works and is moving horizontally as desired. The entire menu is now visible and the user can scroll the bio section to see the overflow of the text, with the skills scroller being fixed to the bottom of the screen.

Things that need to be fixed:

- The mask is not working on the scroller
- There seems to be a discrepancy in the spacing of the items within the scroller.
- Fix the project menu similarly, so that the project-category and project-lists are visible in their entirety, and there is a scroller for the project descriptions.