### PR TITLE
Loads images when project menu is clicked

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -8,6 +8,12 @@ function showProjects() {
 
     // Show projects content
     document.getElementById('project-container').classList.remove('hidden');
+
+    // Load Images
+    var images = document.querySelectorAll('.project-image');
+    images.forEach(function(image) {
+        image.setAttribute('loading', 'eager')
+    });
 }
 
 function showProjectList(category) {


### PR DESCRIPTION
This commit implements a better version of lazy loading. Instead of loading each project image when the project description is clicked, all of the images are loaded when the project menu is clicked. This is achieved by using a javascript function to change the loading attritube to eager when the project menu is clicked. This way, images are loaded and the animation always looks smooth